### PR TITLE
chore: remove deprecated plugin wrapper

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'java'
     id "com.github.node-gradle.node" version "5.0.0"
     id "io.freefair.lombok" version "8.0.1"
-    id "run.halo.plugin.devtools" version "0.0.6"
+    id "run.halo.plugin.devtools" version "0.0.9"
 }
 
 group 'run.halo.stackedit'
@@ -16,7 +16,7 @@ repositories {
 }
 
 dependencies {
-    implementation platform('run.halo.tools.platform:plugin:2.9.0-SNAPSHOT')
+    implementation platform('run.halo.tools.platform:plugin:2.10.0-SNAPSHOT')
     compileOnly 'run.halo.app:api'
 
     testImplementation 'run.halo.app:api'

--- a/src/main/java/run/halo/stackedit/StackEditPlugin.java
+++ b/src/main/java/run/halo/stackedit/StackEditPlugin.java
@@ -1,8 +1,9 @@
 package run.halo.stackedit;
 
-import org.pf4j.PluginWrapper;
 import org.springframework.stereotype.Component;
+
 import run.halo.app.plugin.BasePlugin;
+import run.halo.app.plugin.PluginContext;
 
 /**
  * @author ryanwang
@@ -11,8 +12,8 @@ import run.halo.app.plugin.BasePlugin;
 @Component
 public class StackEditPlugin extends BasePlugin {
 
-    public StackEditPlugin(PluginWrapper wrapper) {
-        super(wrapper);
+    public StackEditPlugin(PluginContext context) {
+        super(context);
     }
 
     @Override

--- a/src/main/resources/plugin.yaml
+++ b/src/main/resources/plugin.yaml
@@ -4,7 +4,7 @@ metadata:
   name: PluginStackEdit
 spec:
   enabled: true
-  requires: ">=2.1.0"
+  requires: ">=2.10.0"
   author:
     name: Halo OSS Team
     website: https://github.com/halo-dev


### PR DESCRIPTION
### What this PR does?
移除对已过时的 PluginWrapper 的引用

see also https://github.com/halo-dev/halo/pull/6243

```release-note
None
```